### PR TITLE
Fix metadata processor for endpoint without params

### DIFF
--- a/src/process-inversify-metadata.ts
+++ b/src/process-inversify-metadata.ts
@@ -23,12 +23,14 @@ export default function processMetadata(metadata: Metadata[], decoratorData: {})
     const controllerName = controller.controllerMetadata.target.name;
     const endpoints = controller.methodMetadata.reduce((endpointResult, endpoint) => {
       const paramData = controller.parameterMetadata[endpoint.key];
-      const params = paramData.filter(p => p.type > 1).map((data): Param => {
+      
+      const params = paramData? paramData.filter(p => p.type > 1).map((data): Param => {
         return { name: data.parameterName, inputType: PARAMETER_TYPE[data.type], index: data.index};
-      });
+      }): [];
       const doc = getDocForEndpoint(decoratorData, controllerName, endpoint.key);
       const endpointData: Endpoint = { key: endpoint.key, method: endpoint.method, path: endpoint.path, params: params, more: {}, doc: doc};
       endpointResult[endpoint.key] = endpointData;
+
       return endpointResult;
     }, {});
     const data: ControllerDefinition = { basePath: controller.controllerMetadata.path, methods: endpoints};


### PR DESCRIPTION
I had an endpoint in a controller with the route "/", but with no params. When generating the documentation for this controller, there is an error. This PR solves this problem by checking if the param data is available and returning an empty array if it is not (which means there are no params).

![screenshot from 2018-09-26 16-56-51](https://user-images.githubusercontent.com/18252261/46106243-a0243d80-c1ae-11e8-8670-c9333731fd35.png)

![screenshot from 2018-09-26 17-03-09](https://user-images.githubusercontent.com/18252261/46106233-9ac6f300-c1ae-11e8-993c-39e90b4ed379.png)
